### PR TITLE
Fix reloading sources.list

### DIFF
--- a/debrebuild.py
+++ b/debrebuild.py
@@ -464,11 +464,12 @@ class Rebuilder:
                 self.required_timestamp_sources.append(timestamp_source)
                 logger.debug("Timestamp source ({} packages): {}".format(len(pkgs), timestamp_source))
                 fd.write("\n{}".format(timestamp_source))
-                fd.seek(0)
+                fd.flush()
 
+                # provides sources.list explicitly, otherwise `update()`
+                # doesn't reload it until the next `open()`
+                self.tempaptcache.update(sources_list=temp_sources_list)
                 self.tempaptcache.open()
-                self.tempaptcache.update()
-                self.tempaptcache.close()
 
                 for notfound_pkg in notfound_packages[:]:
                     pkg = self.tempaptcache.get("{}:{}".format(
@@ -479,6 +480,8 @@ class Rebuilder:
                     #     logger.debug("{} {} {}".format(
                     #         notfound_pkg.name, notfound_pkg.version,
                     #         notfound_pkg.architecture))
+
+                self.tempaptcache.close()
 
         if notfound_packages:
             for notfound_pkg in notfound_packages:


### PR DESCRIPTION
Documentation of apt.Cache() says open() needs to be called after
update(), to have the package list loaded.
But also, it seems update() doesn't reload `sources.list` file - only
open() does. To avoid opening the cache twice, provide sources.list path
explicitly, which also triggers its reload. The side effect is ignoring
sources.list.d, but we don't use it here anyway.